### PR TITLE
Do not include glext.h if glew.h is also included

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(glfont
       GIT_REPOSITORY https://github.com/ami-iit/GLFont
-      GIT_TAG 64a02d6dc382e2bc052e90b15d80cc9792d689c5)
+      GIT_TAG 52224ec565066425ff761dea86b37503f33e03e3)
 
     FetchContent_GetProperties(glfont)
     if(NOT glfont_POPULATED)

--- a/src/devices/openxrheadset/OpenGLConfig.h
+++ b/src/devices/openxrheadset/OpenGLConfig.h
@@ -22,12 +22,10 @@
 #elif defined(__APPLE__)
  #define GLFW_EXPOSE_NATIVE_COCOA
  #define GLFW_EXPOSE_NATIVE_NSGL
-#include <GL/glext.h>
  #include <GL/glx.h>
 #elif defined(__linux__)
  #define GLFW_EXPOSE_NATIVE_X11
  #define GLFW_EXPOSE_NATIVE_GLX
-#include <GL/glext.h>
  #include <GL/glx.h>
 #endif
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/65009898/incompatible-function-prototypes-between-glew-h-and-glext-h .