### PR TITLE
Add missing link to glm imported target

### DIFF
--- a/src/devices/openxrheadset/CMakeLists.txt
+++ b/src/devices/openxrheadset/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(yarp_openxrheadset
     Eigen3::Eigen
     GLFont::GLFont
     stb_image
+    glm
 )
 
 if (NOT WIN32)


### PR DESCRIPTION
I noticed this while debugging https://github.com/ami-iit/yarp-device-openxrheadset/issues/35 . Everything was working fine as glm is an header-only library, but anyhow it is correct to link `glm` as the library is using glm-related headers.