### PR TITLE
Allow labels to follow eyes.

### DIFF
--- a/src/devices/openxrheadset/EyesManager.cpp
+++ b/src/devices/openxrheadset/EyesManager.cpp
@@ -254,3 +254,13 @@ std::string EyesManager::getRightImageControlPortName()
     return m_rightEye.controlPortName();
 }
 
+Eigen::Quaternionf EyesManager::getLeftEyeDesiredRotation() const
+{
+    return m_leftEye.getDesiredEyeRotation();
+}
+
+Eigen::Quaternionf EyesManager::getRightEyeDesiredRotation() const
+{
+    return m_rightEye.getDesiredEyeRotation();
+}
+

--- a/src/devices/openxrheadset/EyesManager.h
+++ b/src/devices/openxrheadset/EyesManager.h
@@ -88,6 +88,10 @@ public:
 
     std::string getRightImageControlPortName();
 
+    Eigen::Quaternionf getLeftEyeDesiredRotation() const;
+
+    Eigen::Quaternionf getRightEyeDesiredRotation() const;
+
 private:
 
     SingleEyePort m_leftEye, m_rightEye;

--- a/src/devices/openxrheadset/LabelPortToQuadLayer.cpp
+++ b/src/devices/openxrheadset/LabelPortToQuadLayer.cpp
@@ -383,6 +383,8 @@ bool LabelPortToQuadLayer::Options::parseFromConfigurationFile(const std::string
     pixelSize = labelGroup.check("pixel_size", yarp::os::Value(64)).asInt32();
     automaticallyEnabled = labelGroup.check("automatically_enabled", yarp::os::Value(true)).asBool();
     disableTimeoutInS = labelGroup.check("disable_timeout_in_S", yarp::os::Value(-1.0)).asFloat64();
+    followEyes = labelGroup.check("follow_eyes") && (labelGroup.find("follow_eyes").isNull() || labelGroup.find("follow_eyes").asBool());
+
 
     std::string inputHorAlignement = labelGroup.check("horizontal_alignement", yarp::os::Value("center")).asString();
     std::transform(inputHorAlignement.begin(), inputHorAlignement.end(), inputHorAlignement.begin(), ::tolower);

--- a/src/devices/openxrheadset/LabelPortToQuadLayer.h
+++ b/src/devices/openxrheadset/LabelPortToQuadLayer.h
@@ -45,6 +45,7 @@ public:
         };
 
         bool automaticallyEnabled{true};
+        bool followEyes{false};
         double disableTimeoutInS{-1.0};
         std::shared_ptr<IOpenXrQuadLayer> quadLayer{nullptr};
         std::string portName;

--- a/src/devices/openxrheadset/SingleEyePort.cpp
+++ b/src/devices/openxrheadset/SingleEyePort.cpp
@@ -192,6 +192,11 @@ void SingleEyePort::setImageDimensions(float widthInMeters, float heightInMeters
     m_layer.setDimensions(widthInMeters, heightInMeters);
 }
 
+Eigen::Quaternionf SingleEyePort::getDesiredEyeRotation() const
+{
+    return m_desiredRotation;
+}
+
 double SingleEyePort::azimuthOffset() const
 {
     return m_azimuthOffset;

--- a/src/devices/openxrheadset/SingleEyePort.h
+++ b/src/devices/openxrheadset/SingleEyePort.h
@@ -51,6 +51,8 @@ public:
 
     void setImageDimensions(float widthInMeters, float heightInMeters);
 
+    Eigen::Quaternionf getDesiredEyeRotation() const;
+
     double azimuthOffset() const;
 
     double elevationOffset() const;


### PR DESCRIPTION
This is useful when gazing. In this way, the label remains in the same relative position of the eyes.