### PR TITLE
Fixed computation of projection matrix in case of asymmetric FOV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build/*
 # Qtcreator
 *.user*
 *.autosave
+
+# Visual Studio
+.vs/
+CmakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(yarp-device-openxrheadset
         LANGUAGES C CXX
-        VERSION 0.0.3)
+        VERSION 0.0.4)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/src/devices/openxrheadset/OpenXrEigenConversions.h
+++ b/src/devices/openxrheadset/OpenXrEigenConversions.h
@@ -14,7 +14,7 @@
 #include <Eigen/Geometry>
 
 
-inline Eigen::Vector3f toEigen(const XrVector3f vector)
+inline Eigen::Vector3f toEigen(const XrVector3f &vector)
 {
     Eigen::Vector3f output;
     output[0] = vector.x;
@@ -23,7 +23,7 @@ inline Eigen::Vector3f toEigen(const XrVector3f vector)
     return output;
 }
 
-inline Eigen::Quaternionf toEigen(const XrQuaternionf quaternion)
+inline Eigen::Quaternionf toEigen(const XrQuaternionf &quaternion)
 {
     Eigen::Quaternionf output;
     output.w() = quaternion.w;

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -248,7 +248,7 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
         }
     }
 
-    double period = cfg.check("vr_period", yarp::os::Value(0.008)).asFloat64(); // 120 Hz, if running at lower frequency, OpenXr will pause waiting for frames
+    double period = cfg.check("vr_period", yarp::os::Value(0.011)).asFloat64();
     this->setPeriod(period);
 
     m_useNativeQuadLayers = cfg.check("use_native_quad_layers") && (cfg.find("use_native_quad_layers").isNull() || cfg.find("use_native_quad_layers").asBool());

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -254,6 +254,7 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
 
     m_openXrInterfaceSettings.posesPredictionInMs = cfg.check("vr_poses_prediction_in_ms", yarp::os::Value(0.0)).asFloat64();
     m_openXrInterfaceSettings.hideWindow = cfg.check("hide_window") && (cfg.find("hide_window").isNull() || cfg.find("hide_window").asBool());
+    m_openXrInterfaceSettings.renderInPlaySpace = cfg.check("render_in_play_space") && (cfg.find("render_in_play_space").isNull() || cfg.find("render_in_play_space").asBool());
 
     m_getStickAsAxis = cfg.check("stick_as_axis", yarp::os::Value(false)).asBool();
     m_rootFrame = cfg.check("tf_root_frame", yarp::os::Value("openxr_origin")).asString();

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -248,7 +248,7 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
         }
     }
 
-    double period = cfg.check("vr_period", yarp::os::Value(0.011)).asFloat64();
+    double period = cfg.check("vr_period", yarp::os::Value(0.008)).asFloat64(); // 120 Hz, if running at lower frequency, OpenXr will pause waiting for frames
     this->setPeriod(period);
 
     m_useNativeQuadLayers = cfg.check("use_native_quad_layers") && (cfg.find("use_native_quad_layers").isNull() || cfg.find("use_native_quad_layers").asBool());

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -317,6 +317,7 @@ private:
     std::atomic_bool m_closed{ false };
 
     OpenXrInterfaceSettings m_openXrInterfaceSettings;
+    bool m_useNativeQuadLayers{ false };
     OpenXrInterface m_openXrInterface;
 
     std::vector<bool> m_buttons;

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -901,6 +901,9 @@ void OpenXrInterface::updateXrSpaces()
     }
     m_pimpl->mid_views_pose.position = toXr(Eigen::Vector3f(toEigen(m_pimpl->mid_views_pose.position)/static_cast<float>(m_pimpl->views.size())));
 
+    m_pimpl->mid_views_pose_inverted.orientation = toXr(toEigen(m_pimpl->mid_views_pose.orientation).inverse());
+    m_pimpl->mid_views_pose_inverted.position = toXr(toEigen(m_pimpl->mid_views_pose_inverted.orientation) * -toEigen(m_pimpl->mid_views_pose.position));
+
     for (size_t i = 0; i < m_pimpl->views.size(); ++i)
     {
         m_pimpl->projection_views[i].pose = m_pimpl->mid_views_pose;
@@ -1180,7 +1183,8 @@ void OpenXrInterface::render()
             {
                 if (viewIsValid)
                 {
-                    openGLLayer->setOffsetPosition(toEigen(m_pimpl->views[0].pose.position));
+                    Eigen::Vector3f offset = toEigen(m_pimpl->mid_views_pose_inverted.orientation) * toEigen(m_pimpl->views[0].pose.position) + toEigen(m_pimpl->mid_views_pose_inverted.position);
+                    openGLLayer->setOffsetPosition(offset);
                 }
                 else
                 {
@@ -1229,7 +1233,8 @@ void OpenXrInterface::render()
             {
                 if (viewIsValid)
                 {
-                    openGLLayer->setOffsetPosition(toEigen(m_pimpl->views[1].pose.position));
+                    Eigen::Vector3f offset = toEigen(m_pimpl->mid_views_pose_inverted.orientation) * toEigen(m_pimpl->views[1].pose.position) + toEigen(m_pimpl->mid_views_pose_inverted.position);
+                    openGLLayer->setOffsetPosition(offset);
                 }
                 else
                 {

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -902,6 +902,14 @@ void OpenXrInterface::updateXrSpaces()
         m_pimpl->projection_views[i].fov = m_pimpl->views[i].fov;
     }
 
+    m_pimpl->mid_views_pose = m_pimpl->views[0].pose;
+
+    for (size_t i = 1; i < m_pimpl->views.size(); ++i)
+    {
+        m_pimpl->mid_views_pose.position = toXr(toEigen(m_pimpl->mid_views_pose.position) + toEigen(m_pimpl->views[i].pose.position));
+    }
+    m_pimpl->mid_views_pose.position = toXr(toEigen(m_pimpl->mid_views_pose.position)/static_cast<float>(m_pimpl->views.size()));
+
     result = xrLocateSpace(m_pimpl->view_space, m_pimpl->play_space,
                            m_pimpl->locate_space_time, &m_pimpl->view_space_location);
 

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -505,8 +505,8 @@ bool OpenXrInterface::prepareXrCompositionLayers()
         m_pimpl->depth_projection_views[i].next = NULL;
         m_pimpl->depth_projection_views[i].minDepth = 0.f;
         m_pimpl->depth_projection_views[i].maxDepth = 1.f;
-        m_pimpl->depth_projection_views[i].nearZ = 0.01f;
-        m_pimpl->depth_projection_views[i].farZ = 100.0f;
+        m_pimpl->depth_projection_views[i].nearZ = m_pimpl->nearZ;
+        m_pimpl->depth_projection_views[i].farZ = m_pimpl->farZ;
 
         m_pimpl->depth_projection_views[i].subImage.swapchain = m_pimpl->projection_view_depth_swapchains[i].swapchain;
         m_pimpl->depth_projection_views[i].subImage.imageArrayIndex = 0;
@@ -1186,6 +1186,7 @@ void OpenXrInterface::render()
         if (openGLLayer->shouldRender() && (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::LEFT_EYE || openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES))
         {
             openGLLayer->setFOVs(m_pimpl->views[0].fov);
+            openGLLayer->setDepthLimits(m_pimpl->nearZ, m_pimpl->farZ);
             if (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES || !openGLLayer->offsetIsSet())
             {
                 if (viewIsValid)
@@ -1236,6 +1237,7 @@ void OpenXrInterface::render()
         if (openGLLayer->shouldRender() && (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::RIGHT_EYE || openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES))
         {
             openGLLayer->setFOVs(m_pimpl->views[1].fov);
+            openGLLayer->setDepthLimits(m_pimpl->nearZ, m_pimpl->farZ);
             if (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES || !openGLLayer->offsetIsSet())
             {
                 if (viewIsValid)

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -1301,6 +1301,7 @@ void OpenXrInterface::endXrFrame()
         {
             if (layer->shouldSubmit())
             {
+                layer->layer.pose = toXr(toEigen(m_pimpl->mid_views_pose) * toEigen(layer->desiredHeadFixedPose));
                 m_pimpl->submitLayer((XrCompositionLayerBaseHeader*) &layer->layer);
             }
         }
@@ -1450,7 +1451,7 @@ std::shared_ptr<IOpenXrQuadLayer> OpenXrInterface::addHeadFixedQuadLayer()
         .type = XR_TYPE_COMPOSITION_LAYER_QUAD,
         .next = NULL,
         .layerFlags = 0,
-        .space = m_pimpl->view_space,        //Head fixed
+        .space = m_pimpl->play_space,        //Head fixed
         .eyeVisibility = XR_EYE_VISIBILITY_BOTH,
         .subImage = {
             .swapchain = XR_NULL_HANDLE,

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -906,9 +906,9 @@ void OpenXrInterface::updateXrSpaces()
 
     for (size_t i = 1; i < m_pimpl->views.size(); ++i)
     {
-        m_pimpl->mid_views_pose.position = toXr(toEigen(m_pimpl->mid_views_pose.position) + toEigen(m_pimpl->views[i].pose.position));
+        m_pimpl->mid_views_pose.position = toXr(Eigen::Vector3f(toEigen(m_pimpl->mid_views_pose.position) + toEigen(m_pimpl->views[i].pose.position)));
     }
-    m_pimpl->mid_views_pose.position = toXr(toEigen(m_pimpl->mid_views_pose.position)/static_cast<float>(m_pimpl->views.size()));
+    m_pimpl->mid_views_pose.position = toXr(Eigen::Vector3f(toEigen(m_pimpl->mid_views_pose.position)/static_cast<float>(m_pimpl->views.size())));
 
     result = xrLocateSpace(m_pimpl->view_space, m_pimpl->play_space,
                            m_pimpl->locate_space_time, &m_pimpl->view_space_location);
@@ -1301,7 +1301,7 @@ void OpenXrInterface::endXrFrame()
         {
             if (layer->shouldSubmit())
             {
-                layer->layer.pose = toXr(toEigen(m_pimpl->mid_views_pose) * toEigen(layer->desiredHeadFixedPose));
+                layer->layer.pose = toXr(Eigen::Matrix4f(toEigen(m_pimpl->mid_views_pose) * toEigen(layer->desiredHeadFixedPose)));
                 m_pimpl->submitLayer((XrCompositionLayerBaseHeader*) &layer->layer);
             }
         }

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -1185,7 +1185,7 @@ void OpenXrInterface::render()
     {
         if (openGLLayer->shouldRender() && (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::LEFT_EYE || openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES))
         {
-            openGLLayer->setFOVs(std::abs(m_pimpl->views[0].fov.angleLeft) + std::abs(m_pimpl->views[0].fov.angleRight), std::abs(m_pimpl->views[0].fov.angleUp) + std::abs(m_pimpl->views[0].fov.angleDown));
+            openGLLayer->setFOVs(m_pimpl->views[0].fov);
             if (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES || !openGLLayer->offsetIsSet())
             {
                 if (viewIsValid)
@@ -1235,7 +1235,7 @@ void OpenXrInterface::render()
     {
         if (openGLLayer->shouldRender() && (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::RIGHT_EYE || openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES))
         {
-            openGLLayer->setFOVs(std::abs(m_pimpl->views[1].fov.angleLeft) + std::abs(m_pimpl->views[1].fov.angleRight), std::abs(m_pimpl->views[1].fov.angleUp) + std::abs(m_pimpl->views[1].fov.angleDown));
+            openGLLayer->setFOVs(m_pimpl->views[1].fov);
             if (openGLLayer->visibility() == IOpenXrQuadLayer::Visibility::BOTH_EYES || !openGLLayer->offsetIsSet())
             {
                 if (viewIsValid)

--- a/src/devices/openxrheadset/OpenXrInterface.h
+++ b/src/devices/openxrheadset/OpenXrInterface.h
@@ -65,6 +65,7 @@ struct OpenXrInterfaceSettings
 {
     double posesPredictionInMs{0.0};
     bool hideWindow{false};
+    bool renderInPlaySpace{false};
 };
 
 class OpenXrInterface

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
@@ -115,9 +115,9 @@ void OpenGLQuadLayer::render()
     glm::mat4 model = m_offsetTra * modelPose * sca;
 
     // Calculate perspective matrix
-    float left = -m_zNear * std::tan(m_fov.angleLeft);
+    float left = m_zNear * std::tan(m_fov.angleLeft);
     float right = m_zNear * std::tan(m_fov.angleRight);
-    float bottom = -m_zNear * std::tan(m_fov.angleDown);
+    float bottom = m_zNear * std::tan(m_fov.angleDown);
     float top = m_zNear * std::tan(m_fov.angleUp);
 
     glm::mat4 perspective_matrix = glm::mat4(0.0f);

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
@@ -120,7 +120,17 @@ void OpenGLQuadLayer::render()
     float bottom = -m_zNear * std::tan(m_fov.angleDown);
     float top = m_zNear * std::tan(m_fov.angleUp);
 
-    glm::mat4 perspective_matrix = glm::frustum(left, right, bottom, top, m_zNear, m_zFar);
+    glm::mat4 perspective_matrix = glm::mat4(0.0f);
+    //The sintax for glm::mat4 is [col][row]
+    //Source https://learnwebgl.brown37.net/08_projections/projections_perspective.html
+    perspective_matrix[0][0] = (2.0f * m_zNear) / (right - left);
+    perspective_matrix[1][1] = (2.0f * m_zNear) / (top - bottom);
+    perspective_matrix[2][2] = -(m_zFar + m_zNear) / (m_zFar - m_zNear);
+    perspective_matrix[2][3] = -1.0f;
+    perspective_matrix[3][0] = -m_zNear * (right + left) / (right - left);
+    perspective_matrix[3][1] = -m_zNear * (top + bottom) / (top - bottom);
+    perspective_matrix[3][2] = -(2.0f * m_zFar * m_zNear) / (m_zFar - m_zNear);
+
 
     glm::mat4 layerTransform = perspective_matrix * model;
 

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
@@ -122,13 +122,13 @@ void OpenGLQuadLayer::render()
 
     glm::mat4 perspective_matrix = glm::mat4(0.0f);
     //The sintax for glm::mat4 is [col][row]
-    //Source https://learnwebgl.brown37.net/08_projections/projections_perspective.html
+    //Source "Generalized Perspective Projection" By Robert Kooima.
     perspective_matrix[0][0] = (2.0f * m_zNear) / (right - left);
     perspective_matrix[1][1] = (2.0f * m_zNear) / (top - bottom);
+    perspective_matrix[2][0] = (right + left) / (right - left);
+    perspective_matrix[2][1] = (top + bottom) / (top - bottom);
     perspective_matrix[2][2] = -(m_zFar + m_zNear) / (m_zFar - m_zNear);
     perspective_matrix[2][3] = -1.0f;
-    perspective_matrix[3][0] = -m_zNear * (right + left) / (right - left);
-    perspective_matrix[3][1] = -m_zNear * (top + bottom) / (top - bottom);
     perspective_matrix[3][2] = -(2.0f * m_zFar * m_zNear) / (m_zFar - m_zNear);
 
 

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
@@ -18,6 +18,12 @@ bool OpenGLQuadLayer::initialize(int32_t imageMaxWidth, int32_t imageMaxHeight)
     m_imageMaxWidth = imageMaxWidth;
     m_imageMaxHeight = imageMaxHeight;
 
+    //Random initialization for FOV
+    m_fov.angleLeft = -1.0f;
+    m_fov.angleRight = 1.0f;
+    m_fov.angleUp = 1.0f;
+    m_fov.angleDown = -1.0f;
+
     m_positions = {
         // vertex coords         // texture coords
         -0.5f, -0.5f, 0.0, 1.0f, 0.0f, 0.0f, // 0 (the first 4 numbers of the row are the vertex coordinates, the second 2 numbers are the texture coordinate for that vertex (the bottom left corner of the rectangle is also the bottom left corner of the picture))
@@ -75,19 +81,18 @@ bool OpenGLQuadLayer::initialize(int32_t imageMaxWidth, int32_t imageMaxHeight)
 void OpenGLQuadLayer::setFOVs(const XrFovf& fov)
 {
     // Calculate horizontal and vertical FOVs
-    float horizontal_fov = std::abs(fov.angleLeft) + std::abs(fov.angleRight);
-    float vertical_fov = std::abs(fov.angleUp) + std::abs(fov.angleDown);
 
-    float tan_vfov_2 = std::tan(vertical_fov / 2.0f);
-
-    if (tan_vfov_2 < 1e-15)
+    if (std::abs(fov.angleRight - fov.angleLeft) < 1e-15)
     {
-        yCError(OPENXRHEADSET) << "Vertical FOV is zero. Cannot calculate aspect ratio.";
+        yCError(OPENXRHEADSET) << "Horizontal FOV is zero.";
         return;
     }
 
-    // Calculate aspect ratio using trigonometry
-    m_aspectRatio = std::tan(horizontal_fov / 2.0f) / tan_vfov_2; //TODO check if needed
+    if (std::abs(fov.angleUp - fov.angleDown) < 1e-15)
+    {
+        yCError(OPENXRHEADSET) << "Vertical FOV is zero.";
+        return;
+    }
     m_fov = fov;
 }
 

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.h
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.h
@@ -52,9 +52,9 @@ class OpenGLQuadLayer : public IOpenXrQuadLayer
 
     glm::vec3 m_modelScale{1.0f, 1.0f, 1.0f};
 
-    float m_fovY = glm::radians(60.0f);                                                      // Field Of View
     float m_zNear = 0.1f;
     float m_zFar = 100.0f;
+    XrFovf m_fov;
     float m_aspectRatio = 1.0f;
 
 public:
@@ -73,7 +73,7 @@ public:
 
     bool initialize(int32_t imageMaxWidth, int32_t imageMaxHeight);
 
-    void setFOVs(float fovX, float fovY);
+    void setFOVs(const XrFovf& fov);
 
     void setDepthLimits(float zNear, float zFar);
 

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.h
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.h
@@ -55,7 +55,6 @@ class OpenGLQuadLayer : public IOpenXrQuadLayer
     float m_zNear = 0.1f;
     float m_zFar = 100.0f;
     XrFovf m_fov;
-    float m_aspectRatio = 1.0f;
 
 public:
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -363,6 +363,9 @@ public:
 
     // Flag to enable the window visualization
     bool hideWindow{false};
+
+    // Flag to enable the visualization of the layers in the play space instead of the head space
+    bool renderInPlaySpace{false};
 };
 
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -369,6 +369,10 @@ public:
 
     // Flag to enable the visualization of the layers in the play space instead of the head space
     bool renderInPlaySpace{false};
+
+    // Depth limits
+    float nearZ = 0.01f;
+    float farZ = 100.0f;
 };
 
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -274,6 +274,9 @@ public:
     // position of a frame in the middle of the eyes, oriented as the first eye
     XrPosef mid_views_pose;
 
+    // position of a frame in the middle of the eyes, oriented as the first eye
+    XrPosef mid_views_pose_inverted;
+
     // List of top level paths to retrieve the state of each action
     std::vector<TopLevelPath> top_level_paths;
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -271,6 +271,9 @@ public:
     // array of views, filled by the runtime with current HMD display pose (basically the position of each eye)
     std::vector<XrView> views;
 
+    // position of a frame in the middle of the eyes, oriented as the first eye
+    XrPosef mid_views_pose;
+
     // List of top level paths to retrieve the state of each action
     std::vector<TopLevelPath> top_level_paths;
 

--- a/src/devices/openxrheadset/impl/OpenXrQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenXrQuadLayer.cpp
@@ -24,12 +24,12 @@ void OpenXrQuadLayer::setPose(const Eigen::Vector3f &position, const Eigen::Quat
 
 void OpenXrQuadLayer::setPosition(const Eigen::Vector3f &position)
 {
-    layer.pose.position = toXr(position);
+    desiredHeadFixedPose.position = toXr(position);
 }
 
 void OpenXrQuadLayer::setQuaternion(const Eigen::Quaternionf &quaternion)
 {
-    layer.pose.orientation = toXr(quaternion);
+    desiredHeadFixedPose.orientation = toXr(quaternion);
 }
 
 void OpenXrQuadLayer::setDimensions(float widthInMeters, float heightInMeters)
@@ -180,12 +180,12 @@ float OpenXrQuadLayer::layerHeight() const
 
 Eigen::Vector3f OpenXrQuadLayer::layerPosition() const
 {
-    return toEigen(layer.pose.position);
+    return toEigen(desiredHeadFixedPose.position);
 }
 
 Eigen::Quaternionf OpenXrQuadLayer::layerQuaternion() const
 {
-    return toEigen(layer.pose.orientation);
+    return toEigen(desiredHeadFixedPose.orientation);
 }
 
 void OpenXrQuadLayer::setEnabled(bool enabled)

--- a/src/devices/openxrheadset/impl/OpenXrQuadLayer.h
+++ b/src/devices/openxrheadset/impl/OpenXrQuadLayer.h
@@ -19,6 +19,7 @@ class OpenXrQuadLayer : public IOpenXrQuadLayer
 public:
 
     XrCompositionLayerQuad layer;
+    XrPosef desiredHeadFixedPose;
     std::vector<XrSwapchainImageOpenGLKHR> swapchain_images;
     uint32_t swapchainWidth;
     uint32_t swapchainHeight;


### PR DESCRIPTION
This PR also adds some option to change the reference frame in which the layers are specified, and to use the OpenXR native QuadLayers