### PR TITLE
Added methods to create the JoypadControlServer device internally

### DIFF
--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -251,6 +251,8 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
     double period = cfg.check("vr_period", yarp::os::Value(0.011)).asFloat64();
     this->setPeriod(period);
 
+    m_launchJoypadControlServer = cfg.check("launch_joypad_control_server") && (cfg.find("launch_joypad_control_server").isNull() || cfg.find("launch_joypad_control_server").asBool());
+
     m_useNativeQuadLayers = cfg.check("use_native_quad_layers") && (cfg.find("use_native_quad_layers").isNull() || cfg.find("use_native_quad_layers").asBool());
 
     m_openXrInterfaceSettings.posesPredictionInMs = cfg.check("vr_poses_prediction_in_ms", yarp::os::Value(0.0)).asFloat64();
@@ -1045,6 +1047,11 @@ bool yarp::dev::OpenXrHeadset::resetTransforms()
 bool yarp::dev::OpenXrHeadset::startJoypadControlServer()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (!m_launchJoypadControlServer)
+    {
+        return true;
+    }
 
     yarp::os::Property options;
     options.put("device", "joypadControlServer");

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -251,7 +251,7 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
     double period = cfg.check("vr_period", yarp::os::Value(0.011)).asFloat64();
     this->setPeriod(period);
 
-    m_launchJoypadControlServer = cfg.check("launch_joypad_control_server") && (cfg.find("launch_joypad_control_server").isNull() || cfg.find("launch_joypad_control_server").asBool());
+    m_autoJoypadControlServer = cfg.check("joypad_control_server_auto") && (cfg.find("joypad_control_server_auto").isNull() || cfg.find("joypad_control_server_auto").asBool());
 
     m_useNativeQuadLayers = cfg.check("use_native_quad_layers") && (cfg.find("use_native_quad_layers").isNull() || cfg.find("use_native_quad_layers").asBool());
 
@@ -614,7 +614,7 @@ void yarp::dev::OpenXrHeadset::run()
         return;
     }
 
-    if (shouldResetJoypadServer)
+    if (shouldResetJoypadServer && m_autoJoypadControlServer)
     {
         startJoypadControlServer();
     }
@@ -1044,14 +1044,15 @@ bool yarp::dev::OpenXrHeadset::resetTransforms()
     return true;
 }
 
-bool yarp::dev::OpenXrHeadset::startJoypadControlServer()
+bool yarp::dev::OpenXrHeadset::restartJoypadControlServer()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
+    startJoypadControlServer();
+}
 
-    if (!m_launchJoypadControlServer)
-    {
-        return true;
-    }
+bool yarp::dev::OpenXrHeadset::startJoypadControlServer()
+{
+    stopJoypadControlServer();
 
     yarp::os::Property options;
     options.put("device", "joypadControlServer");

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -343,6 +343,7 @@ private:
     std::vector<float> m_axes;
     std::vector<Eigen::Vector2f> m_thumbsticks;
 
+    bool m_launchJoypadControlServer{ false };
     std::unique_ptr<yarp::dev::PolyDriver> m_joypadControlServerPtr;
     yarp::dev::IWrapper* m_joypadControlServerWrapper = nullptr;
     yarp::dev::PolyDriver m_thisDevice;

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -354,7 +354,7 @@ private:
     yarp::dev::IWrapper* m_joypadControlServerWrapper = nullptr;
     yarp::dev::PolyDriver m_thisDevice;
 
-    std::mutex m_mutex;
+    std::mutex m_mutex, m_joypadServerMutex;
 
 };
 

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -263,6 +263,9 @@ public:
      * as it will reset all the transforms, including the ones that are not published by this module.
      */
     virtual bool resetTransforms() override;
+
+private:
+
     /**
     * Opens the joypad control server. It reopens it if already opened.
     */
@@ -272,8 +275,6 @@ public:
     * Closes the joypad control server.
     */
     void stopJoypadControlServer();
-
-private:
 
     struct GuiParam
     {

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -264,6 +264,12 @@ public:
      */
     virtual bool resetTransforms() override;
 
+    /**
+     * Start the joypad control server. The server will restart if already started.
+     * @return True if the server is started successfully, false otherwise.
+     */
+    virtual bool restartJoypadControlServer() override;
+
 private:
 
     /**
@@ -343,7 +349,7 @@ private:
     std::vector<float> m_axes;
     std::vector<Eigen::Vector2f> m_thumbsticks;
 
-    bool m_launchJoypadControlServer{ false };
+    bool m_autoJoypadControlServer{ false };
     std::unique_ptr<yarp::dev::PolyDriver> m_joypadControlServerPtr;
     yarp::dev::IWrapper* m_joypadControlServerWrapper = nullptr;
     yarp::dev::PolyDriver m_thisDevice;

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -20,6 +20,7 @@
 #include <yarp/dev/IJoypadController.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ServiceInterfaces.h>
+#include <yarp/dev/IWrapper.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Matrix.h>
 #include <yarp/os/Stamp.h>
@@ -262,6 +263,15 @@ public:
      * as it will reset all the transforms, including the ones that are not published by this module.
      */
     virtual bool resetTransforms() override;
+    /**
+    * Opens the joypad control server. It reopens it if already opened.
+    */
+    bool startJoypadControlServer();
+
+    /**
+    * Closes the joypad control server.
+    */
+    void stopJoypadControlServer();
 
 private:
 
@@ -331,6 +341,10 @@ private:
     std::vector<bool> m_buttons;
     std::vector<float> m_axes;
     std::vector<Eigen::Vector2f> m_thumbsticks;
+
+    std::unique_ptr<yarp::dev::PolyDriver> m_joypadControlServerPtr;
+    yarp::dev::IWrapper* m_joypadControlServerWrapper = nullptr;
+    yarp::dev::PolyDriver m_thisDevice;
 
     std::mutex m_mutex;
 

--- a/src/devices/openxrheadset/thrifts/OpenXrHeadsetCommands.thrift
+++ b/src/devices/openxrheadset/thrifts/OpenXrHeadsetCommands.thrift
@@ -187,4 +187,10 @@ service OpenXrHeadsetCommands
      * as it will reset all the transforms, including the ones that are not published by this module.
      */
      bool resetTransforms();
+
+     /**
+     * Start the joypad control server. The server will restart if already started.
+     * @return True if the server is started successfully, false otherwise.
+     */
+     bool restartJoypadControlServer();
 }


### PR DESCRIPTION
Fixes #49. In particular, instead of relying on an external attach between the ``OpenXR`` device and the ``JoypadControlServer``, this modification allows running the ``JoypadControlServer`` internally, and rebooting it every time it is needed.