### PR TITLE
Use lower case glfw3 in find_package to use upstream config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ find_package(YCM REQUIRED)
 find_package(YARP 3.4 COMPONENTS os sig dev math idl_tools REQUIRED)
 find_package(Threads REQUIRED)
 find_package(OpenXR 1.0.20 REQUIRED)
-find_package(GLFW3 REQUIRED)
+find_package(glfw3 REQUIRED)
 find_package(GLEW REQUIRED) #Helps with the OpenGL configuration on Windows
 find_package(GLM REQUIRED)
 find_package(Eigen3 REQUIRED)


### PR DESCRIPTION
The `FindGLFW3` YCM module was deprecated in https://github.com/robotology/ycm-cmake-modules/pull/441 and removed in https://github.com/robotology/ycm-cmake-modules/pull/465 . 

This fix compilation with YCM 0.18.0 and breaks compilation with apt dependencies on Ubuntu 18.04, but I think this is ok.