### PR TITLE
Use libgl-devel to install OpenGL loader on Linux instead of CDTs

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -40,10 +40,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        # OpenGL is not found on Ubuntu when using conda. Related issue https://github.com/robotology/robotology-superbuild/issues/929
-        # See https://github.com/robotology/robotology-superbuild/issues/477
-        # See https://github.com/robotology/robotology-superbuild/pull/1606
-        conda install expat freeglut libselinux-cos7-x86_64 xorg-libxau libxcb xorg-libxdamage xorg-libxext xorg-libxfixes xorg-libxxf86vm xorg-libxrandr mesa-libgl-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 xorg-xorgproto
+        conda install libgl-devel xorg-xorgproto
 
     - name: Configure [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
This should be part of a much bigger cleanup of all the places in which we use OpenGL-related CDTs in `ami-iit` and `robotology`, but let's start from somewhere.

In a nutshell, now conda-forge packages the so-called [`libglvnd` library](https://gitlab.freedesktop.org/glvnd/libglvnd), that is the loader library linked by the programs and that then loads the OpenGL libraries, so it is now sufficient to just install `libgl-devel` (or `libegl-devel` or other similar packages, depending on the library you actually use) instead of installing a lot of CDTs to compile a library that uses OpenGL. 

Note that `libgl-devel` only install the GL loader library used to **compile** and **link** the library that uses OpenGL. To actually **run** a program that loads OpenGL, you need to install the OpenGL drivers, that are not packaged by conda-forge, and should instead be installed with the system package manager, for example:
* Debian/Ubuntu: `sudo apt-get install libgl1-mesa-dri libglx-mesa0 libegl-mesa0`
* Fedora/RHEL: `sudo dnf install mesa-libGL mesa-libEGL mesa-dri-drivers`

Related docs:
* https://conda-forge.org/docs/maintainer/maintainer_faq/#how-do-i-fix-the-libglso1-import-error