### PR TITLE
Fix compatibility with YARP 3.10 by adding missing header

### DIFF
--- a/src/utils/OpenXrFrameViz/main.cpp
+++ b/src/utils/OpenXrFrameViz/main.cpp
@@ -13,6 +13,7 @@
 #include <yarp/dev/IFrameTransform.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/ResourceFinder.h>
+#include <yarp/conf/version.h>
 
 #include <iostream>
 #include <cstdlib>


### PR DESCRIPTION
Due to a missing header, https://github.com/ami-iit/yarp-device-openxrheadset/pull/59 fixed compatibility with YARP 3.11. but broke YARP 3.10 . Including the correct header make sure that the project is able to build with both YARP 3.10 and 3.11 .