### PR TITLE
Fix compilation with Ubuntu 22.04 apt dependencies with CMake 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  YCM_TAG: v0.14.0
-  YARP_TAG: v3.6.0
+  YCM_TAG: v0.18.2
+  YARP_TAG: v3.10.0
   OPENXR_TAG: main
   MONADO_TAG: main
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 ### Dependencies
+
+# Temporary set CMAKE_POLICY_VERSION_MINIMUM 3.5 as a workaround 
+# for https://github.com/robotology/gz-sim-yarp-plugins/pull/258#issue-2963247728
+# Remove once we drop support for compilation on Ubuntu 22.04 with apt dependencies
+# find_package(jsoncpp) is transitively called by find_package(OpenXR)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+    if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+        set(YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK ${CMAKE_POLICY_VERSION_MINIMUM})
+    endif()
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
+
 # Fetching GLFont for displaying labels
 option(YARP_OPENXR_USES_SYSTEM_GLFont OFF)
 if(YARP_OPENXR_USES_SYSTEM_GLFont)
@@ -90,26 +102,7 @@ endif()
 find_package(YCM REQUIRED)
 find_package(YARP 3.4 COMPONENTS os sig dev math idl_tools REQUIRED)
 find_package(Threads REQUIRED)
-
-# Temporary set CMAKE_POLICY_VERSION_MINIMUM 3.5 as a workaround 
-# for https://github.com/robotology/gz-sim-yarp-plugins/pull/258#issue-2963247728
-# Remove once we drop support for compilation on Ubuntu 22.04 with apt dependencies
-# find_package(jsoncpp) is transitively called by find_package(OpenXR)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
-    if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
-        set(YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK ${CMAKE_POLICY_VERSION_MINIMUM})
-    endif()
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-endif()
 find_package(OpenXR 1.0.20 REQUIRED)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
-    if(DEFINED YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK)
-        set(CMAKE_POLICY_VERSION_MINIMUM ${YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK})
-    else()
-        unset(CMAKE_POLICY_VERSION_MINIMUM)
-    endif()
-endif()
-
 find_package(glfw3 REQUIRED)
 find_package(GLEW REQUIRED) #Helps with the OpenGL configuration on Windows
 find_package(GLM REQUIRED)
@@ -124,6 +117,15 @@ find_package(OpenGL REQUIRED)
 
 if (NOT WIN32)
     find_package(X11 REQUIRED)
+endif()
+
+# Cleanup the value of CMAKE_POLICY_VERSION_MINIMUM set before finding all dependencies
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+    if(DEFINED YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK)
+        set(CMAKE_POLICY_VERSION_MINIMUM ${YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK})
+    else()
+        unset(CMAKE_POLICY_VERSION_MINIMUM)
+    endif()
 endif()
 
 # Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(glfont
       GIT_REPOSITORY https://github.com/ami-iit/GLFont
-      GIT_TAG bd6b7290c5e51e58662c80dbbdf28858c1ded9b3)
+      GIT_TAG 68914f7093acb485c01fe661e7b4b2cb91921bef)
 
     FetchContent_GetProperties(glfont)
     if(NOT glfont_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,26 @@ endif()
 find_package(YCM REQUIRED)
 find_package(YARP 3.4 COMPONENTS os sig dev math idl_tools REQUIRED)
 find_package(Threads REQUIRED)
+
+# Temporary set CMAKE_POLICY_VERSION_MINIMUM 3.5 as a workaround 
+# for https://github.com/robotology/gz-sim-yarp-plugins/pull/258#issue-2963247728
+# Remove once we drop support for compilation on Ubuntu 22.04 with apt dependencies
+# find_package(jsoncpp) is transitively called by find_package(OpenXR)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+    if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+        set(YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK ${CMAKE_POLICY_VERSION_MINIMUM})
+    endif()
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
 find_package(OpenXR 1.0.20 REQUIRED)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
+    if(DEFINED YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK)
+        set(CMAKE_POLICY_VERSION_MINIMUM ${YDOXH_CMAKE_POLICY_VERSION_MINIMUM_BACK})
+    else()
+        unset(CMAKE_POLICY_VERSION_MINIMUM)
+    endif()
+endif()
+
 find_package(glfw3 REQUIRED)
 find_package(GLEW REQUIRED) #Helps with the OpenGL configuration on Windows
 find_package(GLM REQUIRED)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1835 .

This fix is required as CMake was upgraded (indipendently from apt) to CMake 4.0.0 in the GitHub Actions image, but the `/usr/lib/x86_64-linux-gnu/cmake/jsoncpp/jsoncppConfig.cmake` (invoked indirectly via `find_package(OpenXR)`) has a `cmake_minimum_required` call that is not compatible with CMake 4.0.0 . Setting `CMAKE_POLICY_VERSION_MINIMUM` env variable to `3.5` should solve this problem.