### PR TITLE
Attempt to fix conda forge builds

### DIFF
--- a/.github/workflows/conda-forge-ci.yml
+++ b/.github/workflows/conda-forge-ci.yml
@@ -40,7 +40,12 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        conda install libgl-devel xorg-xorgproto
+        conda install libgl-devel xorg-xorgproto xorg-libxrandr
+        
+    - name: Conda list
+      shell: bash -l {0}
+      run: |
+        conda list
 
     - name: Configure [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
Need to install xorg-libxrandr manually.

Apparently, this is needed since a couple of days (first failing job https://github.com/ami-iit/yarp-device-openxrheadset/actions/runs/14787532364/job/41518543009). Checking the output with a working CI, I noticed the following

```diff
--- C:\Users\sdafarra\Downloads\env_working.txt
+++ C:\Users\sdafarra\Downloads\env_not_wroking.txt
@@ -10,7 +10,6 @@
     cyrus-sasl-2.1.27          |       h54b06d7_7         214 KB  conda-forge
     dav1d-1.2.1                |       hd590300_0         742 KB  conda-forge
     dbus-1.13.6                |       h5008d03_3         604 KB  conda-forge
-    double-conversion-3.3.1    |       h5888daf_0          68 KB  conda-forge
     eigen-3.4.0                |       h00ab1b0_0         1.0 MB  conda-forge
     expat-2.7.0                |       h5888daf_0         137 KB  conda-forge
     ffmpeg-7.1.1               | gpl_h0b79d52_704         9.9 MB  conda-forge
@@ -29,8 +28,8 @@
     gettext-tools-0.23.1       |       h5888daf_0         2.8 MB  conda-forge
     glew-2.1.0                 |       h9c3ff4c_2         647 KB  conda-forge
     glfw-3.4                   |       hd590300_0         163 KB  conda-forge
-    glib-2.84.1                |       h07242d1_0         593 KB  conda-forge
-    glib-tools-2.84.1          |       h4833e2c_0         114 KB  conda-forge
+    glib-2.84.1                |       h6287aef_1         595 KB  conda-forge
+    glib-tools-2.84.1          |       h4833e2c_1         114 KB  conda-forge
     glm-1.0.1                  |       hdd259ec_0         290 KB  conda-forge
     gmp-6.3.0                  |       hac33072_2         449 KB  conda-forge
     graphite2-1.3.13           |    h59595ed_1003          95 KB  conda-forge
@@ -55,8 +54,8 @@
     libblas-3.9.0              |31_h59b9bed_openblas          16 KB  conda-forge
     libcap-2.75                |       h39aace5_0         118 KB  conda-forge
     libcblas-3.9.0             |31_he106b2a_openblas          16 KB  conda-forge
-    libclang-cpp20.1-20.1.3    |default_h1df26ce_0        19.9 MB  conda-forge
-    libclang13-20.1.3          |default_he06ed0a_0        11.5 MB  conda-forge
+    libclang-cpp20.1-20.1.4    |default_h1df26ce_0        19.9 MB  conda-forge
+    libclang13-20.1.4          |default_he06ed0a_0        11.5 MB  conda-forge
     libcups-2.3.3              |       h4637d8d_4         4.3 MB  conda-forge
     libdb-6.2.32               |       h9c3ff4c_0        23.3 MB  conda-forge
     libdeflate-1.23            |       h86f0d12_0          71 KB  conda-forge
@@ -72,7 +71,7 @@
     libgettextpo-devel-0.23.1  |       h5888daf_0          36 KB  conda-forge
     libgfortran-14.2.0         |       h69a702a_2          52 KB  conda-forge
     libgl-1.7.0                |       ha4b6fd6_2         132 KB  conda-forge
-    libglib-2.84.1             |       h2ff4ddf_0         3.8 MB  conda-forge
+    libglib-2.84.1             |       h3618099_1         3.8 MB  conda-forge
     libglu-9.0.3               |       h03adeef_0         318 KB  conda-forge
     libglvnd-1.7.0             |       ha4b6fd6_2         129 KB  conda-forge
     libglx-1.7.0               |       ha4b6fd6_2          74 KB  conda-forge
@@ -88,7 +87,7 @@
     libntlm-1.8                |       hb9d3cd8_0          33 KB  conda-forge
     libogg-1.3.5               |       hd0c01bc_1         213 KB  conda-forge
     libopenblas-0.3.29         |pthreads_h94d23a6_0         5.6 MB  conda-forge
-    libopencv-4.11.0           |qt6_py39h2c622e1_607        29.4 MB  conda-forge
+    libopencv-4.11.0           |headless_py310hada27fe_7        28.9 MB  conda-forge
     libopenvino-2025.0.0       |       hdc3f47d_3         5.4 MB  conda-forge
     libopenvino-auto-batch-plugin-2025.0.0|       h4d9b6c2_3         109 KB  conda-forge
     libopenvino-auto-plugin-2025.0.0|       h4d9b6c2_3         233 KB  conda-forge
@@ -141,7 +140,7 @@
     openxr-sdk-1.1.47          |       hf42df4d_0         217 KB  conda-forge
     packaging-25.0             |     pyh29332c3_1          61 KB  conda-forge
     pango-1.56.3               |       h9ac818e_1         442 KB  conda-forge
-    pcre2-10.44                |       hc749103_2         934 KB  conda-forge
+    pcre2-10.45                |       hc749103_0         1.1 MB  conda-forge
     pip-25.1                   |     pyh8b19718_0         1.2 MB  conda-forge
     pixman-0.46.0              |       h29eaf8c_0         389 KB  conda-forge
     portaudio-19.7.0           |       hf4617a5_0          76 KB  conda-forge
@@ -151,14 +150,13 @@
     python-3.12.10             |h9e4cc4f_0_cpython        29.8 MB  conda-forge
     python_abi-3.12            |          7_cp312           7 KB  conda-forge
     qt-main-5.15.15            |       h993ce98_3        50.2 MB  conda-forge
-    qt6-main-6.8.3             |       h6441bc3_1        48.5 MB  conda-forge
     rav1e-0.6.6                |       he8a937b_2        14.7 MB  conda-forge
     readline-8.2               |       h8c095d6_2         276 KB  conda-forge
     robot-testing-framework-2.0.1|       hcb278e6_1         181 KB  conda-forge
     sdl-1.2.68                 |       h9b8e6db_1         153 KB  conda-forge
     sdl2-2.32.54               |       h3f2d84a_0         573 KB  conda-forge
     sdl3-3.2.10                |       h5c8443d_1         1.9 MB  conda-forge
-    setuptools-79.0.1          |     pyhff2d567_0         769 KB  conda-forge
+    setuptools-80.1.0          |     pyhff2d567_0         760 KB  conda-forge
     snappy-1.2.1               |       h8bd8927_1          42 KB  conda-forge
     soxr-0.1.3                 |       h0b41bf4_3         128 KB  conda-forge
     svt-av1-3.0.2              |       h5888daf_0         2.6 MB  conda-forge
@@ -171,7 +169,6 @@
     x264-1!164.3095            |       h166bdaf_2         877 KB  conda-forge
     x265-3.5                   |       h924138e_3         3.2 MB  conda-forge
     xcb-util-0.4.1             |       hb711507_2          19 KB  conda-forge
-    xcb-util-cursor-0.1.5      |       hb9d3cd8_0          20 KB  conda-forge
     xcb-util-image-0.4.0       |       hb711507_2          24 KB  conda-forge
     xcb-util-keysyms-0.4.1     |       hb711507_0          14 KB  conda-forge
     xcb-util-renderutil-0.3.10 |       hb711507_0          17 KB  conda-forge
@@ -181,7 +178,6 @@
     xorg-libsm-1.2.6           |       he73a12e_0          27 KB  conda-forge
     xorg-libx11-1.8.12         |       h4f16b4b_0         816 KB  conda-forge
     xorg-libxau-1.0.12         |       hb9d3cd8_0          14 KB  conda-forge
-    xorg-libxcomposite-0.4.6   |       hb9d3cd8_2          13 KB  conda-forge
     xorg-libxcursor-1.2.3      |       hb9d3cd8_0          32 KB  conda-forge
     xorg-libxdamage-1.1.6      |       hb9d3cd8_0          13 KB  conda-forge
     xorg-libxdmcp-1.1.5        |       hb9d3cd8_0          19 KB  conda-forge
@@ -189,11 +185,9 @@
     xorg-libxfixes-6.0.1       |       hb9d3cd8_0          19 KB  conda-forge
     xorg-libxi-1.8.2           |       hb9d3cd8_0          46 KB  conda-forge
     xorg-libxinerama-1.1.5     |       h5888daf_1          14 KB  conda-forge
-    xorg-libxrandr-1.5.4       |       hb9d3cd8_0          29 KB  conda-forge
     xorg-libxrender-0.9.12     |       hb9d3cd8_0          32 KB  conda-forge
     xorg-libxscrnsaver-1.2.4   |       hb9d3cd8_0          14 KB  conda-forge
     xorg-libxshmfence-1.3.3    |       hb9d3cd8_0          12 KB  conda-forge
-    xorg-libxtst-1.2.5         |       hb9d3cd8_3          32 KB  conda-forge
     xorg-libxxf86vm-1.1.6      |       hb9d3cd8_0          17 KB  conda-forge
     yarp-3.11.2                |       h7fb1b56_1          15 KB  conda-forge
     yarp-python-3.11.2         |  py312h687071c_1         1.1 MB  conda-forge
```

A notable difference is that ``qt6-main`` is no more present, possibly causing a series of ``xorg`` packages not being downloaded