### PR TITLE
Fix iDynTree warning

### DIFF
--- a/src/utils/OpenXrFrameViz/main.cpp
+++ b/src/utils/OpenXrFrameViz/main.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <iDynTree/Visualizer.h>
-#include <iDynTree/yarp/YARPConversions.h>
+#include <iDynTree/YARPConversions.h>
 
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IFrameTransform.h>


### PR DESCRIPTION
The warning:

~~~
 In file included from /home/runner/work/robotology-superbuild/robotology-superbuild/src/yarp-device-openxrheadset/src/utils/OpenXrFrameViz/main.cpp:10:
/home/runner/work/robotology-superbuild/robotology-superbuild/b/install/include/iDynTree/yarp/YARPConversions.h:7:4: warning: #warning <iDynTree/yarp/YARPConversions.h> is deprecated. Please use <iDynTree/YARPConversions.h>. To disable this warning use -Wno-deprecated. [-Wcpp]
    7 |   #warning <iDynTree/yarp/YARPConversions.h> is deprecated. Please use <iDynTree/YARPConversions.h>. To disable this warning use -Wno-deprecated.
      |    ^~~~~~~
~~~

in the superbuild was annoying. 