### PR TITLE
Quad layer pose in view space and change texture filtering

### DIFF
--- a/src/devices/openxrheadset/ImagePortToQuadLayer.h
+++ b/src/devices/openxrheadset/ImagePortToQuadLayer.h
@@ -121,6 +121,8 @@ public:
         glBindTexture(GL_TEXTURE_2D, m_imageTexture);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                GL_TEXTURE_2D, m_imageTexture, 0);
         glTexImage2D(GL_TEXTURE_2D, 0, m_pixelFormat, quadLayer->imageMaxWidth(), quadLayer->imageMaxHeight(), 0,
@@ -219,7 +221,7 @@ public:
         //Copy from the read framebuffer to the draw framebuffer
         glBlitFramebuffer(startX, endY, endX, startY,
             0, 0, m_quadLayer->imageMaxWidth(), m_quadLayer->imageMaxHeight(),
-            GL_COLOR_BUFFER_BIT, GL_NEAREST);   // When writing the texture, OpenGl starts from the bottom left corner and
+            GL_COLOR_BUFFER_BIT, GL_LINEAR);   // When writing the texture, OpenGl starts from the bottom left corner and
                                                 // goes from left to right, bottom to up.
                                                 // See https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
                                                 // In Yarp, the first pixel is the top left, so we have to flip vertically.

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -1793,7 +1793,14 @@ void OpenXrInterface::endXrFrame()
 #ifdef DEBUG_RENDERING_LOCATION
                 layer->layer.pose = layer->desiredHeadFixedPose;
 #else
-                layer->layer.pose = toXr(Eigen::Matrix4f(toEigen(m_pimpl->mid_views_pose) * toEigen(layer->desiredHeadFixedPose)));
+                if (m_pimpl->renderInPlaySpace)
+                {
+                    layer->layer.pose = toXr(Eigen::Matrix4f(toEigen(m_pimpl->mid_views_pose) * toEigen(layer->desiredHeadFixedPose)));
+                }
+                else
+                {
+                    layer->layer.pose = layer->desiredHeadFixedPose;
+                }
 #endif
 
                 m_pimpl->submitLayer((XrCompositionLayerBaseHeader*) &layer->layer);

--- a/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
+++ b/src/devices/openxrheadset/impl/OpenGLQuadLayer.cpp
@@ -243,7 +243,7 @@ bool OpenGLQuadLayer::submitImage(int32_t xOffset, int32_t yOffset, int32_t imag
     //Copy from the read framebuffer to the draw framebuffer
     glBlitNamedFramebuffer(m_userBuffer.id(), m_internalBuffer.id(), xOffset, yOffset, xOffset + imageWidth, yOffset + imageHeight,
         0, 0, imageMaxWidth(), imageMaxHeight(),
-        GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 //Resetting read and draw framebuffers
     m_userBuffer.unbind();


### PR DESCRIPTION
When projecting an image in the headset, I noticed a continuous jitter. Some investigations with Claude led to this PR. 

So, this PR introduces the following:

-  Change quad layer pose computation when using native quad layers (`--use_native_quad_layers`):  When using native quad layers, layers are created in VIEW space, where poses are inherently head-relative. The old code multiplied the desired pose by the current head pose on every frame, introducing frame-to-frame jitter from head-tracking noise. The fix skips this multiplication when the layer space is VIEW space.
- Switch texture blit filtering from `GL_NEAREST` to `GL_LINEAR` in both `ImagePortToQuadLayer` and `OpenGLQuadLayer` to avoid pixelation when the image is scaled to the layer size. Also add explicit min/mag filter parameters to the intermediate texture setup.

How to test: Run the device with `--use_native_quad_layers` and verify that overlays are stable and correctly positioned without jittering.