### PR TITLE
Fix deadlock on controller connect and disable body tracking in joystick mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/*
 .vs/
 CmakeSettings.json
 .vscode
+
+# Mine
+build*

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -295,10 +295,41 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
     m_openXrInterfaceSettings.useExpressions = !noExpressions;
 
     bool noHandTracking = cfg.check("no_hand_tracking") && (cfg.find("no_hand_tracking").isNull() || cfg.find("no_hand_tracking").asBool());
-    m_openXrInterfaceSettings.useHandTracking = !noHandTracking;
+    std::string inputTypeString = cfg.check("input_type", yarp::os::Value("auto")).asString();
+    std::transform(inputTypeString.begin(), inputTypeString.end(), inputTypeString.begin(), ::tolower);
+    if (inputTypeString == "auto")
+    {
+        m_openXrInterfaceSettings.inputType = OpenXrInputType::AUTO;
+        m_openXrInterfaceSettings.useHandTracking = !noHandTracking;
+    }
+    else if (inputTypeString == "hands")
+    {
+        m_openXrInterfaceSettings.inputType = OpenXrInputType::HANDS;
+        m_openXrInterfaceSettings.useHandTracking = true;
+        if (noHandTracking)
+        {
+            yCWarning(OPENXRHEADSET) << "Both input_type=hands and no_hand_tracking were specified. input_type takes priority and hand tracking will stay enabled.";
+        }
+    }
+    else if (inputTypeString == "joysticks")
+    {
+        m_openXrInterfaceSettings.inputType = OpenXrInputType::JOYSTICKS;
+        m_openXrInterfaceSettings.useHandTracking = false;
+        m_openXrInterfaceSettings.useFbBodyTracking = false;
+        yCInfo(OPENXRHEADSET) << "input_type=joysticks selected. Hand tracking and body tracking disabled.";
+    }
+    else
+    {
+        yCError(OPENXRHEADSET) << "Unrecognized input_type:" << inputTypeString << ". Allowed values are: auto, hands, joysticks.";
+        return false;
+    }
 
-	bool noFbBodyTracking = cfg.check("no_fb_body_tracking") && (cfg.find("no_fb_body_tracking").isNull() || cfg.find("no_fb_body_tracking").asBool());
-	m_openXrInterfaceSettings.useFbBodyTracking = !noFbBodyTracking;
+    // Body tracking: disabled automatically for joystick mode, otherwise configurable
+    if (m_openXrInterfaceSettings.inputType != OpenXrInputType::JOYSTICKS)
+    {
+        bool noFbBodyTracking = cfg.check("no_fb_body_tracking") && (cfg.find("no_fb_body_tracking").isNull() || cfg.find("no_fb_body_tracking").asBool());
+        m_openXrInterfaceSettings.useFbBodyTracking = !noFbBodyTracking;
+    }
 
     auto parsePoseFilterType = [](const std::string& str, PoseFilterType& filterType) -> bool
     {
@@ -606,109 +637,111 @@ void yarp::dev::OpenXrHeadset::threadRelease()
 
 void yarp::dev::OpenXrHeadset::run()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-
     bool shouldResetJoypadServer = false;
 
-    if (m_openXrInterface.isRunning())
     {
-        if (!m_eyesManager.update()) {
-            yCError(OPENXRHEADSET) << "Failed to update eyes.";
-        }
+        std::lock_guard<std::mutex> lock(m_mutex);
 
-        Eigen::Vector3f leftAngles = EulerAngles::XYZ(m_eyesManager.getLeftEyeDesiredRotation().matrix());
-        Eigen::Vector3f rightAngles = EulerAngles::XYZ(m_eyesManager.getRightEyeDesiredRotation().matrix());
-
-        double averageElevation = (leftAngles[0] + rightAngles[0]) / 2.0;
-        double averageAzimuth = (leftAngles[1] + rightAngles[1]) / 2.0;
-
-        Eigen::Quaternionf averageRotation = Eigen::AngleAxisf(averageElevation, Eigen::Vector3f::UnitX()) *
-            Eigen::AngleAxisf(averageAzimuth, Eigen::Vector3f::UnitY());
-
-        for (GuiParam& gui : m_huds)
+        if (m_openXrInterface.isRunning())
         {
-            if (gui.followEyes)
+            if (!m_eyesManager.update()) {
+                yCError(OPENXRHEADSET) << "Failed to update eyes.";
+            }
+
+            Eigen::Vector3f leftAngles = EulerAngles::XYZ(m_eyesManager.getLeftEyeDesiredRotation().matrix());
+            Eigen::Vector3f rightAngles = EulerAngles::XYZ(m_eyesManager.getRightEyeDesiredRotation().matrix());
+
+            double averageElevation = (leftAngles[0] + rightAngles[0]) / 2.0;
+            double averageAzimuth = (leftAngles[1] + rightAngles[1]) / 2.0;
+
+            Eigen::Quaternionf averageRotation = Eigen::AngleAxisf(averageElevation, Eigen::Vector3f::UnitX()) *
+                Eigen::AngleAxisf(averageAzimuth, Eigen::Vector3f::UnitY());
+
+            for (GuiParam& gui : m_huds)
             {
-                Eigen::Quaternionf newRotation;
-                if (gui.visibility == IOpenXrQuadLayer::Visibility::LEFT_EYE)
+                if (gui.followEyes)
                 {
-                    newRotation = m_eyesManager.getLeftEyeDesiredRotation();
-                }
-                else if (gui.visibility == IOpenXrQuadLayer::Visibility::RIGHT_EYE)
-                {
-                    newRotation = m_eyesManager.getRightEyeDesiredRotation();
-                }
-                else
-                {
-                    newRotation = averageRotation;
+                    Eigen::Quaternionf newRotation;
+                    if (gui.visibility == IOpenXrQuadLayer::Visibility::LEFT_EYE)
+                    {
+                        newRotation = m_eyesManager.getLeftEyeDesiredRotation();
+                    }
+                    else if (gui.visibility == IOpenXrQuadLayer::Visibility::RIGHT_EYE)
+                    {
+                        newRotation = m_eyesManager.getRightEyeDesiredRotation();
+                    }
+                    else
+                    {
+                        newRotation = averageRotation;
+                    }
+
+                    Eigen::Vector3f guiPosition = { gui.x, gui.y, gui.z };
+                    gui.layer.setPose(newRotation * guiPosition, newRotation);
                 }
 
-                Eigen::Vector3f guiPosition = { gui.x, gui.y, gui.z };
-                gui.layer.setPose(newRotation * guiPosition, newRotation);
+                if (!gui.layer.updateTexture()) {
+                    yCError(OPENXRHEADSET) << "Failed to update" << gui.portName << "display texture.";
+                }
             }
 
-            if (!gui.layer.updateTexture()) {
-                yCError(OPENXRHEADSET) << "Failed to update" << gui.portName << "display texture.";
-            }
-        }
-
-        for (LabelLayer& label : m_labels)
-        {
-            if (label.options.followEyes)
+            for (LabelLayer& label : m_labels)
             {
-                Eigen::Vector3f labelPosition = { label.x, label.y, label.z };
-                label.layer.setPosition(averageRotation * labelPosition);
+                if (label.options.followEyes)
+                {
+                    Eigen::Vector3f labelPosition = { label.x, label.y, label.z };
+                    label.layer.setPosition(averageRotation * labelPosition);
+                }
+
+                if (!label.layer.updateTexture()) {
+                    yCError(OPENXRHEADSET) << "Failed to update" << label.options.portName << "label.";
+                }
+            }
+            for (SlideLayer& slide : m_slides)
+            {
+                if (!slide.layer.updateTexture()) {
+                    yCError(OPENXRHEADSET) << "Failed to update" << slide.options.portName << "slide.";
+                }
+            }
+            m_openXrInterface.draw(m_drawableArea);
+
+            size_t previousButtonsSize = m_buttons.size();
+            size_t previousAxesSize = m_axes.size();
+            size_t previousThumbsticksSize = m_thumbsticks.size();
+
+            m_openXrInterface.getButtons(m_buttons);
+            m_openXrInterface.getAxes(m_axes);
+            m_openXrInterface.getThumbsticks(m_thumbsticks);
+
+            if (m_buttons.size() != previousButtonsSize ||
+                m_axes.size() != previousAxesSize ||
+                m_thumbsticks.size() != previousThumbsticksSize)
+            {
+                shouldResetJoypadServer = true;
             }
 
-            if (!label.layer.updateTexture()) {
-                yCError(OPENXRHEADSET) << "Failed to update" << label.options.portName << "label.";
+            m_openXrInterface.getAllPoses(m_posesManager.inputs());
+
+            if (m_openXrInterface.shouldResetLocalReferenceSpace())
+            {
+                //The local reference space has been changed by the user.
+                m_rootFrameRawHRootFrame.position.setZero();
+                m_rootFrameRawHRootFrame.rotation.setIdentity();
             }
+
+            //Publish the transformation from the root frame to the OpenXR root frame
+            m_posesManager.setTransformFromRawToRootFrame(m_rootFrameRawHRootFrame);
+
+            m_posesManager.publishFrames();
+
+            m_expressionsManager.setExpressions(m_openXrInterface.eyeExpressions(), m_openXrInterface.lipExpressions());
+            m_expressionsManager.setGazeInHeadFrame(m_openXrInterface.gazePoseInViewFrame());
         }
-        for (SlideLayer& slide : m_slides)
+        else
         {
-            if (!slide.layer.updateTexture()) {
-                yCError(OPENXRHEADSET) << "Failed to update" << slide.options.portName << "slide.";
-            }
+            close();
+            return;
         }
-        m_openXrInterface.draw(m_drawableArea);
-
-        size_t previousButtonsSize = m_buttons.size();
-        size_t previousAxesSize = m_axes.size();
-        size_t previousThumbsticksSize = m_thumbsticks.size();
-
-        m_openXrInterface.getButtons(m_buttons);
-        m_openXrInterface.getAxes(m_axes);
-        m_openXrInterface.getThumbsticks(m_thumbsticks);
-
-        if (m_buttons.size() != previousButtonsSize ||
-            m_axes.size() != previousAxesSize ||
-            m_thumbsticks.size() != previousThumbsticksSize)
-        {
-            shouldResetJoypadServer = true;
-        }
-
-        m_openXrInterface.getAllPoses(m_posesManager.inputs());
-
-        if (m_openXrInterface.shouldResetLocalReferenceSpace())
-        {
-            //The local reference space has been changed by the user.
-            m_rootFrameRawHRootFrame.position.setZero();
-            m_rootFrameRawHRootFrame.rotation.setIdentity();
-        }
-
-        //Publish the transformation from the root frame to the OpenXR root frame
-        m_posesManager.setTransformFromRawToRootFrame(m_rootFrameRawHRootFrame);
-
-        m_posesManager.publishFrames();
-
-        m_expressionsManager.setExpressions(m_openXrInterface.eyeExpressions(), m_openXrInterface.lipExpressions());
-        m_expressionsManager.setGazeInHeadFrame(m_openXrInterface.gazePoseInViewFrame());
-    }
-    else
-    {
-        close();
-        return;
-    }
+    } // m_mutex released here, before calling startJoypadControlServer()
 
     if (shouldResetJoypadServer && m_autoJoypadControlServer)
     {

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -2004,6 +2004,7 @@ bool OpenXrInterface::initialize(const OpenXrInterfaceSettings &settings)
     m_pimpl->use_expressions = settings.useExpressions;
     m_pimpl->use_hand_tracking = settings.useHandTracking;
 	m_pimpl->use_fb_body_tracking = settings.useFbBodyTracking;
+    m_pimpl->input_type = settings.inputType;
     m_pimpl->head_filter_type = settings.headPoseFilterType;
     m_pimpl->hands_filter_type = settings.handsPoseFilterType;
     m_pimpl->htc_trackers_filter_type = settings.trackersPoseFilterType;
@@ -2253,6 +2254,12 @@ std::string OpenXrInterface::currentRightHandInteractionProfile() const
 
 void OpenXrInterface::getButtons(std::vector<bool> &buttons) const
 {
+    if (m_pimpl->input_type == OpenXrInputType::HANDS)
+    {
+        buttons.clear();
+        return;
+    }
+
     size_t numberOfButtons = 0;
     for (auto& topLevelpath : m_pimpl->top_level_paths)
     {
@@ -2275,6 +2282,12 @@ void OpenXrInterface::getButtons(std::vector<bool> &buttons) const
 
 void OpenXrInterface::getAxes(std::vector<float> &axes) const
 {
+    if (m_pimpl->input_type == OpenXrInputType::HANDS)
+    {
+        axes.clear();
+        return;
+    }
+
     size_t numberOfAxes = 0;
     for (auto& topLevelpath : m_pimpl->top_level_paths)
     {
@@ -2297,6 +2310,12 @@ void OpenXrInterface::getAxes(std::vector<float> &axes) const
 
 void OpenXrInterface::getThumbsticks(std::vector<Eigen::Vector2f> &thumbsticks) const
 {
+    if (m_pimpl->input_type == OpenXrInputType::HANDS)
+    {
+        thumbsticks.clear();
+        return;
+    }
+
     size_t numberOfThumbsticks = 0;
     for (auto& topLevelpath : m_pimpl->top_level_paths)
     {
@@ -2319,20 +2338,24 @@ void OpenXrInterface::getThumbsticks(std::vector<Eigen::Vector2f> &thumbsticks) 
 
 void OpenXrInterface::getAllPoses(std::vector<NamedPoseVelocity> &additionalPoses) const
 {
+    bool strictHands = m_pimpl->input_type == OpenXrInputType::HANDS;
     size_t numberOfPoses = 0;
     numberOfPoses += 3; //This is because the head and the hands are added manually
-    for (size_t topLevelIndex = 0; topLevelIndex <  m_pimpl->top_level_paths.size(); ++topLevelIndex)
+    if (!strictHands)
     {
-        if (topLevelIndex < 2) //Left and right hands are already considered with leftHandPose() and rightHandPose()
+        for (size_t topLevelIndex = 0; topLevelIndex <  m_pimpl->top_level_paths.size(); ++topLevelIndex)
         {
-            if (m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size() > 1) //The first element is the one considerd by leftHandPose() and rightHandPose()
+            if (topLevelIndex < 2) //Left and right hands are already considered with leftHandPose() and rightHandPose()
             {
-                numberOfPoses += m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size() - 1;
+                if (m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size() > 1) //The first element is the one considerd by leftHandPose() and rightHandPose()
+                {
+                    numberOfPoses += m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size() - 1;
+                }
             }
-        }
-        else
-        {
-            numberOfPoses += m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size();
+            else
+            {
+                numberOfPoses += m_pimpl->top_level_paths[topLevelIndex].currentActions().poses.size();
+            }
         }
     }
 
@@ -2355,26 +2378,51 @@ void OpenXrInterface::getAllPoses(std::vector<NamedPoseVelocity> &additionalPose
     auto& left_arm = additionalPoses[poseIndex];
     left_arm.name = m_pimpl->leftHandPoseName;
     left_arm.filterType = m_pimpl->hands_filter_type;
-    left_arm.pose = leftHandPose();
-    left_arm.velocity = leftHandVelocity();
+    if (strictHands && m_pimpl->use_hand_tracking &&
+        m_pimpl->leftHandJointPoses.size() > XR_HAND_JOINT_WRIST_EXT)
+    {
+        const auto& wrist = m_pimpl->leftHandJointPoses[XR_HAND_JOINT_WRIST_EXT];
+        const auto& palm = m_pimpl->leftHandJointPoses[XR_HAND_JOINT_PALM_EXT];
+        left_arm.pose = wrist.pose.positionValid && wrist.pose.rotationValid ? wrist.pose : palm.pose;
+        left_arm.velocity = OpenXrInterface::Velocity();
+    }
+    else
+    {
+        left_arm.pose = leftHandPose();
+        left_arm.velocity = leftHandVelocity();
+    }
     poseIndex++;
 
     auto& right_arm = additionalPoses[poseIndex];
     right_arm.name = m_pimpl->rightHandPoseName;
     right_arm.filterType = m_pimpl->hands_filter_type;
-    right_arm.pose = rightHandPose();
-    right_arm.velocity = rightHandVelocity();
+    if (strictHands && m_pimpl->use_hand_tracking &&
+        m_pimpl->rightHandJointPoses.size() > XR_HAND_JOINT_WRIST_EXT)
+    {
+        const auto& wrist = m_pimpl->rightHandJointPoses[XR_HAND_JOINT_WRIST_EXT];
+        const auto& palm = m_pimpl->rightHandJointPoses[XR_HAND_JOINT_PALM_EXT];
+        right_arm.pose = wrist.pose.positionValid && wrist.pose.rotationValid ? wrist.pose : palm.pose;
+        right_arm.velocity = OpenXrInterface::Velocity();
+    }
+    else
+    {
+        right_arm.pose = rightHandPose();
+        right_arm.velocity = rightHandVelocity();
+    }
     poseIndex++;
 
-    for (size_t topLevelIndex = 0; topLevelIndex < m_pimpl->top_level_paths.size(); ++topLevelIndex)
+    if (!strictHands)
     {
-        std::vector<PoseAction>& posesList = m_pimpl->top_level_paths[topLevelIndex].currentActions().poses;
-        // Skip the first pose for left and right hands (already considered)
-        // since the first two top level paths are reserved to left and right hand respectively
-        for (size_t i = (topLevelIndex < 2) ? 1 : 0; i < posesList.size(); ++i)
+        for (size_t topLevelIndex = 0; topLevelIndex < m_pimpl->top_level_paths.size(); ++topLevelIndex)
         {
-            additionalPoses[poseIndex] = posesList[i];
-            poseIndex++;
+            std::vector<PoseAction>& posesList = m_pimpl->top_level_paths[topLevelIndex].currentActions().poses;
+            // Skip the first pose for left and right hands (already considered)
+            // since the first two top level paths are reserved to left and right hand respectively
+            for (size_t i = (topLevelIndex < 2) ? 1 : 0; i < posesList.size(); ++i)
+            {
+                additionalPoses[poseIndex] = posesList[i];
+                poseIndex++;
+            }
         }
     }
 

--- a/src/devices/openxrheadset/OpenXrInterface.h
+++ b/src/devices/openxrheadset/OpenXrInterface.h
@@ -67,6 +67,13 @@ enum class PoseFilterType
     JUMP_FILTER
 };
 
+enum class OpenXrInputType
+{
+    AUTO,
+    HANDS,
+    JOYSTICKS
+};
+
 struct OpenXrInterfaceSettings
 {
     double posesPredictionInMs{0.0};
@@ -77,6 +84,7 @@ struct OpenXrInterfaceSettings
     bool useExpressions{ true };
     bool useHandTracking{ true };
     bool useFbBodyTracking{ true };
+    OpenXrInputType inputType{ OpenXrInputType::AUTO };
     PoseFilterType headPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType handsPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType trackersPoseFilterType{ PoseFilterType::JUMP_FILTER };

--- a/src/devices/openxrheadset/README.md
+++ b/src/devices/openxrheadset/README.md
@@ -43,6 +43,7 @@ This document lists all the configuration parameters parsed by the `OpenXrHeadse
 | `vr_poses_prediction_in_ms` | double | `0.0` | The prediction time for pose tracking, in milliseconds. |
 | `hide_window` | bool (flag) | `true` if `use_native_quad_layers` is set, `false` otherwise | If set (or set to `true`), hides the desktop mirror window. |
 | `render_in_play_space` | bool (flag) | `false` | If set (or set to `true`), renders in the play space instead of the view reference space. |
+| `input_type` | string | `"auto"` | Selects the input source. Allowed values: `"auto"`, `"hands"`, `"joysticks"`. `"hands"` is strict hands-only mode: controller buttons, axes, thumbsticks, and controller poses are not exposed. `"joysticks"` is strict controller-only mode: hand tracking is disabled and hand joints are not published. |
 | `no_gaze` | bool (flag) | `false` | If set (or set to `true`), disables gaze tracking. |
 | `force_use_gaze` | bool (flag) | `false` | If set (or set to `true`), forces the use of gaze tracking even if the runtime reports that the system does not support eye gaze interaction. Device won't start if both `no_gaze` and this flag are set. |
 | `no_expressions` | bool (flag) | `false` | If set (or set to `true`), disables facial expression tracking. |

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -467,6 +467,7 @@ public:
     std::vector<NamedPoseVelocity> fbBodyJointPoses;
 
     // Filters
+    OpenXrInputType input_type = OpenXrInputType::AUTO;
     PoseFilterType head_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType hands_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType htc_trackers_filter_type = PoseFilterType::JUMP_FILTER;


### PR DESCRIPTION
- Move startJoypadControlServer() outside m_mutex lock scope in run() to
  prevent deadlock when JoypadControlServer queries device methods (getButtonCount, etc.)
  during attach. This affected any controller (Oculus, HTC, KHR), not just joysticks.
- input_type=joysticks now also disables body tracking (useFbBodyTracking=false)
- Guard no_fb_body_tracking config so it does not override joystick mode"
