### PR TITLE
Bd body jump filtering

### DIFF
--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -341,7 +341,7 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
         return false;
     }
 
-    std::string bdBodyFilterTypeStr = cfg.check("bd_body_pose_filter_type", yarp::os::Value("jump")).asString();
+    std::string bdBodyFilterTypeStr = cfg.check("bd_body_pose_filter_type", yarp::os::Value("none")).asString();
     if (!parsePoseFilterType(bdBodyFilterTypeStr, m_openXrInterfaceSettings.bdBodyPoseFilterType))
     {
         yCError(OPENXRHEADSET) << "Unrecognized bd_body_pose_filter_type:" << bdBodyFilterTypeStr;

--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -341,6 +341,13 @@ bool yarp::dev::OpenXrHeadset::open(yarp::os::Searchable &cfg)
         return false;
     }
 
+    std::string bdBodyFilterTypeStr = cfg.check("bd_body_pose_filter_type", yarp::os::Value("jump")).asString();
+    if (!parsePoseFilterType(bdBodyFilterTypeStr, m_openXrInterfaceSettings.bdBodyPoseFilterType))
+    {
+        yCError(OPENXRHEADSET) << "Unrecognized bd_body_pose_filter_type:" << bdBodyFilterTypeStr;
+        return false;
+    }
+
     m_getStickAsAxis = cfg.check("stick_as_axis", yarp::os::Value(false)).asBool();
     m_rootFrame = cfg.check("tf_root_frame", yarp::os::Value("openxr_origin")).asString();
     m_rootFrameRaw = m_rootFrame + "_raw";

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -17,12 +17,13 @@ namespace {
 OpenXrInterface::NamedPoseVelocity retargetPoseViaHeadOffset(
     const OpenXrInterface::Pose& offset,
     const OpenXrInterface::NamedPoseVelocity& source,
-    const std::string& outputName)
+    const std::string& outputName,
+    PoseFilterType filterType)
 {
     OpenXrInterface::NamedPoseVelocity result;
     result.name = outputName;
     result.parentFrame = source.parentFrame;
-    result.filterType = PoseFilterType::NONE;
+    result.filterType = filterType;
     result.pose = offset * source.pose;
 
     result.velocity.linearValid  = source.velocity.linearValid  && offset.rotationValid;
@@ -1306,10 +1307,16 @@ bool OpenXrInterface::prepareBdBodyTracking()
     for (size_t i = 0; i < XR_BODY_JOINT_COUNT_BD; ++i)
     {
         auto& joint = m_pimpl->bdBodyJointPoses[i];
-        joint.filterType = PoseFilterType::NONE;
+        joint.filterType = m_pimpl->bd_body_filter_type;
         joint.parentFrame = "";
         std::string joint_name = m_pimpl->getBDBodyJointName(static_cast<XrBodyJointBD>(i));
         joint.name = "bd_body_" + joint_name;
+        // xrLocateBodyJointsBD does not provide velocities. Assume a zero and valid velocity so
+        // that the jump filter falls back to a zero-velocity (i.e. previous pose) prediction.
+        joint.velocity.linear.setZero();
+        joint.velocity.angular.setZero();
+        joint.velocity.linearValid = true;
+        joint.velocity.angularValid = true;
     }
 
     if (m_pimpl->use_hand_tracking)
@@ -1318,14 +1325,14 @@ bool OpenXrInterface::prepareBdBodyTracking()
         for (const auto& finger : m_pimpl->leftHandJointPoses)
         {
             auto& joint = m_pimpl->bdBodyJointPoses[bdAlignedIndex++];
-            joint.filterType = PoseFilterType::NONE;
+            joint.filterType = m_pimpl->bd_body_filter_type;
             joint.parentFrame = "";
             joint.name = openxrToBDBodyName(finger.name);
         }
         for (const auto& finger : m_pimpl->rightHandJointPoses)
         {
             auto& joint = m_pimpl->bdBodyJointPoses[bdAlignedIndex++];
-            joint.filterType = PoseFilterType::NONE;
+            joint.filterType = m_pimpl->bd_body_filter_type;
             joint.parentFrame = "";
             joint.name = openxrToBDBodyName(finger.name);
         }
@@ -1867,12 +1874,12 @@ void OpenXrInterface::updateBdBodyTracking()
                 for (const auto& finger : m_pimpl->leftHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name));
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
                 }
                 for (const auto& finger : m_pimpl->rightHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name));
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
                 }
             }
         }
@@ -2253,6 +2260,7 @@ bool OpenXrInterface::initialize(const OpenXrInterfaceSettings &settings)
     m_pimpl->head_filter_type = settings.headPoseFilterType;
     m_pimpl->hands_filter_type = settings.handsPoseFilterType;
     m_pimpl->htc_trackers_filter_type = settings.trackersPoseFilterType;
+    m_pimpl->bd_body_filter_type = settings.bdBodyPoseFilterType;
 
 #ifdef DEBUG_RENDERING_LOCATION
     m_pimpl->renderInPlaySpace = true;

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -18,7 +18,8 @@ OpenXrInterface::NamedPoseVelocity retargetPoseViaHeadOffset(
     const OpenXrInterface::Pose& offset,
     const OpenXrInterface::NamedPoseVelocity& source,
     const std::string& outputName,
-    PoseFilterType filterType)
+    PoseFilterType filterType,
+    bool ignoreSourceVelocityValidity)
 {
     OpenXrInterface::NamedPoseVelocity result;
     result.name = outputName;
@@ -26,12 +27,21 @@ OpenXrInterface::NamedPoseVelocity retargetPoseViaHeadOffset(
     result.filterType = filterType;
     result.pose = offset * source.pose;
 
-    result.velocity.linearValid  = source.velocity.linearValid  && offset.rotationValid;
-    result.velocity.angularValid = source.velocity.angularValid && offset.rotationValid;
-    if (result.velocity.linearValid)
-        result.velocity.linear  = offset.rotation * source.velocity.linear;
-    if (result.velocity.angularValid)
-        result.velocity.angular = offset.rotation * source.velocity.angular;
+    result.velocity.linear  = offset.rotation * source.velocity.linear;
+    result.velocity.angular = offset.rotation * source.velocity.angular;
+
+    result.velocity.linearValid  = offset.rotationValid;
+    result.velocity.angularValid = offset.rotationValid;
+    
+    if(!ignoreSourceVelocityValidity)
+    {
+        result.velocity.linearValid  = result.velocity.linearValid  && source.velocity.linearValid;
+        result.velocity.angularValid = result.velocity.angularValid && source.velocity.angularValid;
+    } else {
+        result.velocity.linear.setZero();
+        result.velocity.angular.setZero();
+    }
+    
 
     return result;
 }
@@ -1874,12 +1884,12 @@ void OpenXrInterface::updateBdBodyTracking()
                 for (const auto& finger : m_pimpl->leftHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type, true);
                 }
                 for (const auto& finger : m_pimpl->rightHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type, true);
                 }
             }
         }

--- a/src/devices/openxrheadset/OpenXrInterface.cpp
+++ b/src/devices/openxrheadset/OpenXrInterface.cpp
@@ -18,8 +18,7 @@ OpenXrInterface::NamedPoseVelocity retargetPoseViaHeadOffset(
     const OpenXrInterface::Pose& offset,
     const OpenXrInterface::NamedPoseVelocity& source,
     const std::string& outputName,
-    PoseFilterType filterType,
-    bool ignoreSourceVelocityValidity)
+    PoseFilterType filterType)
 {
     OpenXrInterface::NamedPoseVelocity result;
     result.name = outputName;
@@ -27,21 +26,12 @@ OpenXrInterface::NamedPoseVelocity retargetPoseViaHeadOffset(
     result.filterType = filterType;
     result.pose = offset * source.pose;
 
-    result.velocity.linear  = offset.rotation * source.velocity.linear;
-    result.velocity.angular = offset.rotation * source.velocity.angular;
-
-    result.velocity.linearValid  = offset.rotationValid;
-    result.velocity.angularValid = offset.rotationValid;
-    
-    if(!ignoreSourceVelocityValidity)
-    {
-        result.velocity.linearValid  = result.velocity.linearValid  && source.velocity.linearValid;
-        result.velocity.angularValid = result.velocity.angularValid && source.velocity.angularValid;
-    } else {
-        result.velocity.linear.setZero();
-        result.velocity.angular.setZero();
-    }
-    
+    result.velocity.linearValid  = source.velocity.linearValid  && offset.rotationValid;
+    result.velocity.angularValid = source.velocity.angularValid && offset.rotationValid;
+    if (result.velocity.linearValid)
+        result.velocity.linear  = offset.rotation * source.velocity.linear;
+    if (result.velocity.angularValid)
+        result.velocity.angular = offset.rotation * source.velocity.angular;
 
     return result;
 }
@@ -1884,12 +1874,12 @@ void OpenXrInterface::updateBdBodyTracking()
                 for (const auto& finger : m_pimpl->leftHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type, true);
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
                 }
                 for (const auto& finger : m_pimpl->rightHandJointPoses)
                 {
                     m_pimpl->bdBodyJointPoses[bdAlignedIndex++] =
-                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type, true);
+                        retargetPoseViaHeadOffset(offset, finger, openxrToBDBodyName(finger.name), m_pimpl->bd_body_filter_type);
                 }
             }
         }

--- a/src/devices/openxrheadset/OpenXrInterface.h
+++ b/src/devices/openxrheadset/OpenXrInterface.h
@@ -81,6 +81,7 @@ struct OpenXrInterfaceSettings
     PoseFilterType headPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType handsPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType trackersPoseFilterType{ PoseFilterType::JUMP_FILTER };
+    PoseFilterType bdBodyPoseFilterType{ PoseFilterType::JUMP_FILTER };
 };
 
 class OpenXrInterface

--- a/src/devices/openxrheadset/OpenXrInterface.h
+++ b/src/devices/openxrheadset/OpenXrInterface.h
@@ -81,7 +81,7 @@ struct OpenXrInterfaceSettings
     PoseFilterType headPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType handsPoseFilterType{ PoseFilterType::JUMP_FILTER };
     PoseFilterType trackersPoseFilterType{ PoseFilterType::JUMP_FILTER };
-    PoseFilterType bdBodyPoseFilterType{ PoseFilterType::JUMP_FILTER };
+    PoseFilterType bdBodyPoseFilterType{ PoseFilterType::NONE };
 };
 
 class OpenXrInterface

--- a/src/devices/openxrheadset/README.md
+++ b/src/devices/openxrheadset/README.md
@@ -58,6 +58,7 @@ This document lists all the configuration parameters parsed by the `OpenXrHeadse
 | `head_pose_filter_type` | string | `"jump"` | Filter type for the head pose. Allowed values: `"none"`, `"jump"`. |
 | `hands_pose_filter_type` | string | `"jump"` | Filter type for hand poses. Allowed values: `"none"`, `"jump"`. |
 | `trackers_pose_filter_type` | string | `"jump"` | Filter type for tracker poses. Allowed values: `"none"`, `"jump"`. |
+| `bd_body_pose_filter_type` | string | `"jump"` | Filter type for BD (PICO) body joints. Allowed values: `"none"`, `"jump"`. |
 
 ---
 

--- a/src/devices/openxrheadset/README.md
+++ b/src/devices/openxrheadset/README.md
@@ -58,7 +58,7 @@ This document lists all the configuration parameters parsed by the `OpenXrHeadse
 | `head_pose_filter_type` | string | `"jump"` | Filter type for the head pose. Allowed values: `"none"`, `"jump"`. |
 | `hands_pose_filter_type` | string | `"jump"` | Filter type for hand poses. Allowed values: `"none"`, `"jump"`. |
 | `trackers_pose_filter_type` | string | `"jump"` | Filter type for tracker poses. Allowed values: `"none"`, `"jump"`. |
-| `bd_body_pose_filter_type` | string | `"jump"` | Filter type for BD (PICO) body joints. Allowed values: `"none"`, `"jump"`. |
+| `bd_body_pose_filter_type` | string | `"none"` | Filter type for BD (PICO) body joints. Allowed values: `"none"`, `"jump"`. |
 
 ---
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -480,6 +480,7 @@ public:
     PoseFilterType head_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType hands_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType htc_trackers_filter_type = PoseFilterType::JUMP_FILTER;
+    PoseFilterType bd_body_filter_type = PoseFilterType::JUMP_FILTER;
 };
 
 

--- a/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
+++ b/src/devices/openxrheadset/impl/OpenXrInterfaceImpl.h
@@ -480,7 +480,7 @@ public:
     PoseFilterType head_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType hands_filter_type = PoseFilterType::JUMP_FILTER;
     PoseFilterType htc_trackers_filter_type = PoseFilterType::JUMP_FILTER;
-    PoseFilterType bd_body_filter_type = PoseFilterType::JUMP_FILTER;
+    PoseFilterType bd_body_filter_type = PoseFilterType::NONE;
 };
 
 


### PR DESCRIPTION
This PR introduces BD body joint jump filtering. Since velocity metrics are not (yet) available https://github.com/gbionics/yarp-device-openxrheadset/issues/88 a 0 velocity is used for such poses.
This means that "predicted pose" coincides with "last pose".

Unlike other types of poses, the default filter for BD body joints is set to `none`. This because it has not been yet extensively tested.

As for testing, it gets quite hard to understand whether this filter is really useful or not, since we wanted to leverage it to filter out some big rotation jumps we noticed on the wrists, but that are not really deterministic to reproduce.