### PR TITLE
Remove IService interface implementation

### DIFF
--- a/src/devices/openxrheadset/OpenXrHeadset.cpp
+++ b/src/devices/openxrheadset/OpenXrHeadset.cpp
@@ -727,23 +727,6 @@ void yarp::dev::OpenXrHeadset::run()
 
 }
 
-bool yarp::dev::OpenXrHeadset::startService()
-{
-    //To let the device driver knowing that it need to poll updateService continuosly
-    return false;
-}
-
-bool yarp::dev::OpenXrHeadset::updateService()
-{
-    //To let the device driver that we are still alive
-    return !m_closed;
-}
-
-bool yarp::dev::OpenXrHeadset::stopService()
-{
-    return this->close();
-}
-
 bool yarp::dev::OpenXrHeadset::getAxisCount(unsigned int &axis_count)
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/devices/openxrheadset/OpenXrHeadset.h
+++ b/src/devices/openxrheadset/OpenXrHeadset.h
@@ -19,7 +19,6 @@
 #include <yarp/dev/IFrameTransform.h>
 #include <yarp/dev/IJoypadController.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/ServiceInterfaces.h>
 #include <yarp/dev/IWrapper.h>
 #include <yarp/sig/Image.h>
 #include <yarp/sig/Matrix.h>
@@ -46,7 +45,6 @@ class OpenXrHeadset;
 
 class yarp::dev::OpenXrHeadset : public yarp::dev::DeviceDriver,
                                  public yarp::os::PeriodicThread,
-                                 public yarp::dev::IService,
                                  public yarp::dev::IJoypadController,
                                  public OpenXrHeadsetCommands
 {
@@ -59,15 +57,11 @@ public:
     virtual bool open(yarp::os::Searchable& cfg) override;
     virtual bool close() override;
 
-    // yarp::os::RateThread methods
+    // yarp::os::PeriodicThread methods
     virtual bool threadInit() override;
     virtual void threadRelease() override;
     virtual void run() override;
 
-    //  yarp::dev::IService methods
-    virtual bool startService() override;
-    virtual bool updateService() override;
-    virtual bool stopService() override;
 
     // yarp::dev::IJoypadController methods
     virtual bool getAxisCount(unsigned int& axis_count) override;


### PR DESCRIPTION
As per https://github.com/gbionics/yarp-device-openxrheadset/issues/92 , this PR removes `IService` from the interfaces implemented by `OpenXrHeadset`.

This should also prevent the device from getting stuck when closing (see https://github.com/robotology/yarp/pull/3100).

NOTE: still to be tested